### PR TITLE
Allow custom icon

### DIFF
--- a/BlazorTimeline/BlazorTimeline/BlazorTimeline.csproj
+++ b/BlazorTimeline/BlazorTimeline/BlazorTimeline.csproj
@@ -31,7 +31,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.7" />
     </ItemGroup>
 
     <ItemGroup>

--- a/BlazorTimeline/BlazorTimeline/Timeline.razor
+++ b/BlazorTimeline/BlazorTimeline/Timeline.razor
@@ -5,7 +5,7 @@
     --title-color: @TitleColor; 
     --text-color: @TextColor;
     --text-bg: @TextBgColor">
-        <CascadingValue Name="@nameof(Timeline)" Value="@this">
+        <CascadingValue Name="@nameof(Timeline)" Value="@this" IsFixed="true">
             @ChildContent
         </CascadingValue>
     </div>

--- a/BlazorTimeline/BlazorTimeline/TimelineItem.razor
+++ b/BlazorTimeline/BlazorTimeline/TimelineItem.razor
@@ -1,6 +1,6 @@
 ﻿<div class="timeline-item">
     <div class="timeline-icon">
-        @if (IconContent == null)
+        @if (IconContent != null)
         {
             @IconContent
         }
@@ -24,7 +24,8 @@
         <p>
             @ChildContent
         </p>
-        @if (!string.IsNullOrEmpty(ButtonText)) {
+        @if (!string.IsNullOrEmpty(ButtonText))
+        {
             <a href="@Link" class="timeline-button">@ButtonText</a>
         }
     </div>
@@ -64,6 +65,11 @@
         if (Timeline == null)
             throw new ArgumentNullException(nameof(Timeline),"Must be used within Timeline");
         Timeline.AddTimelineItem(this);
+    }
+
+    protected override void OnParametersSet()
+    {
+        base.OnParametersSet();
     }
 
     public override Task SetParametersAsync(ParameterView parameters) {

--- a/BlazorTimeline/BlazorTimeline/TimelineItem.razor
+++ b/BlazorTimeline/BlazorTimeline/TimelineItem.razor
@@ -67,11 +67,6 @@
         Timeline.AddTimelineItem(this);
     }
 
-    protected override void OnParametersSet()
-    {
-        base.OnParametersSet();
-    }
-
     public override Task SetParametersAsync(ParameterView parameters) {
         Position = parameters.GetValueOrDefault<ItemPosition>(nameof(Position));
         return base.SetParametersAsync(parameters);

--- a/BlazorTimeline/BlazorTimeline/TimelineItem.razor
+++ b/BlazorTimeline/BlazorTimeline/TimelineItem.razor
@@ -1,13 +1,20 @@
 ﻿<div class="timeline-item">
     <div class="timeline-icon">
-        <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-             width="21px" height="20px" viewBox="0 0 21 20" enable-background="new 0 0 21 20" xml:space="preserve">
-            <path fill="#FFFFFF" d="M19.998,6.766l-5.759-0.544c-0.362-0.032-0.676-0.264-0.822-0.61l-2.064-4.999
+        @if (IconContent == null)
+        {
+            @IconContent
+        }
+        else
+        {
+            <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+                 width="21px" height="20px" viewBox="0 0 21 20" enable-background="new 0 0 21 20" xml:space="preserve">
+                <path fill="#FFFFFF" d="M19.998,6.766l-5.759-0.544c-0.362-0.032-0.676-0.264-0.822-0.61l-2.064-4.999
 	c-0.329-0.825-1.5-0.825-1.83,0L7.476,5.611c-0.132,0.346-0.462,0.578-0.824,0.61L0.894,6.766C0.035,6.848-0.312,7.921,0.333,8.499
 	l4.338,3.811c0.279,0.246,0.395,0.609,0.314,0.975l-1.304,5.345c-0.199,0.842,0.708,1.534,1.468,1.089l4.801-2.822
 	c0.313-0.181,0.695-0.181,1.006,0l4.803,2.822c0.759,0.445,1.666-0.23,1.468-1.089l-1.288-5.345
 	c-0.081-0.365,0.035-0.729,0.313-0.975l4.34-3.811C21.219,7.921,20.855,6.848,19.998,6.766z"/>
-        </svg>
+            </svg>
+        }
     </div>
     <div class="timeline-content @(Position == ItemPosition.Right ? "right" : "")">
         <div class="item-title">
@@ -28,6 +35,9 @@
     [Parameter]
     public RenderFragment ChildContent { get; set; }
     
+    [Parameter]
+    public RenderFragment IconContent { get; set; }
+
     /// <summary>
     /// Title for timeline item
     /// </summary>

--- a/BlazorTimeline/Demo/Demo.csproj
+++ b/BlazorTimeline/Demo/Demo.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="5.0.1" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.7" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="5.0.7" PrivateAssets="all" />
         <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
     </ItemGroup>
 

--- a/BlazorTimeline/Demo/Pages/AlteringTimeline.razor
+++ b/BlazorTimeline/Demo/Pages/AlteringTimeline.razor
@@ -24,4 +24,21 @@
     <TimelineItem Title="Left" Position="ItemPosition.Left">
         Hi! I'm left!
     </TimelineItem>
+    
+    <TimelineItem Title="Hey I am a custom icon">
+        <IconContent>
+            <svg width="24" height="24" xmlns="http://www.w3.org/2000/svg">
+             <g id="Layer_1">
+              <title>Layer 1</title>
+              <ellipse filter="url(#svg_4_blur)" transform="rotate(-6 11.9687 12.2016)" ry="11.17721" rx="11.61553" id="svg_4" cy="12.20163" cx="11.96869" stroke="#000" fill="none"/>
+              <ellipse stroke-width="2" ry="0.06262" id="svg_5" cy="3.21603" cx="36.35817" stroke="#000" fill="none"/>
+             </g>
+             <defs>
+              <filter height="200%" width="200%" y="-50%" x="-50%" id="svg_4_blur">
+               <feGaussianBlur stdDeviation="0.5" in="SourceGraphic"/>
+              </filter>
+             </defs>
+            </svg>
+        </IconContent>
+    </TimelineItem>
 </Timeline>

--- a/BlazorTimeline/Demo/Program.cs
+++ b/BlazorTimeline/Demo/Program.cs
@@ -1,12 +1,8 @@
 using System;
 using System.Net.Http;
-using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Text;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 
 namespace Demo {
 	public class Program {
@@ -15,7 +11,7 @@ namespace Demo {
 			builder.RootComponents.Add<App>("#app");
 
 			builder.Services.AddScoped(
-				sp => new HttpClient {BaseAddress = new Uri(builder.HostEnvironment.BaseAddress)});
+				_ => new HttpClient {BaseAddress = new Uri(builder.HostEnvironment.BaseAddress)});
 
 			await builder.Build().RunAsync();
 		}

--- a/BlazorTimeline/Tests/Tests.csproj
+++ b/BlazorTimeline/Tests/Tests.csproj
@@ -7,11 +7,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="bunit" Version="1.0.19" />
+        <PackageReference Include="bunit" Version="1.1.5" />
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
-        <PackageReference Include="NUnit" Version="3.12.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+        <PackageReference Include="NUnit" Version="3.13.2" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/BlazorTimeline/Tests/TimelineTests.cs
+++ b/BlazorTimeline/Tests/TimelineTests.cs
@@ -181,7 +181,7 @@ namespace Tests {
 			// Act
 			var component = _context.RenderComponent<Timeline>(p => {
 				p.AddChildContent<TimelineItem>();
-				p.AddChildContent<TimelineItem>(a => a.Add(a => a.Position, ItemPosition.Left));
+				p.AddChildContent<TimelineItem>(a => a.Add(tlitem => tlitem.Position, ItemPosition.Left));
 			});
 			var timelineItems = component.FindComponents<TimelineItem>();
 			timelineItems.Should().HaveCount(2);
@@ -197,13 +197,13 @@ namespace Tests {
 			// Act
 			var component = _context.RenderComponent<Timeline>(p => {
 				p.Add(a => a.ItemPositionOption, ItemPositionOption.Manual);
-				p.AddChildContent<TimelineItem>(a => a.Add(a => a.Position, ItemPosition.Right));
-				p.AddChildContent<TimelineItem>(a => a.Add(a => a.Position, ItemPosition.Left));
+				p.AddChildContent<TimelineItem>(a => a.Add(tlitem => tlitem.Position, ItemPosition.Right));
+				p.AddChildContent<TimelineItem>(a => a.Add(tlitem => tlitem.Position, ItemPosition.Left));
 			});
 			var timelineItems = component.FindComponents<TimelineItem>();
 			timelineItems.Should().HaveCount(2);
-			var firstTimelineContent = timelineItems[0].Find("div").GetElementsByClassName("timeline-content")[0];;
-			var secondTimelineContent = timelineItems[1].Find("div").GetElementsByClassName("timeline-content")[0];;
+			var firstTimelineContent = timelineItems[0].Find("div").GetElementsByClassName("timeline-content")[0];
+			var secondTimelineContent = timelineItems[1].Find("div").GetElementsByClassName("timeline-content")[0];
 			// Assert
 			firstTimelineContent.ClassList.Should().Contain(a => a == "right");
 			secondTimelineContent.ClassList.Should().NotContain(a => a == "right");


### PR DESCRIPTION
This PR includes the following new behavior:
 * The Icon for TimelineItem can be defined (optional)
 * CascadingParameter set to IsFixed as the child (`TimelineItem`) doesn't need to subscribe to change events from the parent (`Timeline`)
 * Updated NuGet Packages
 * Smaller Code cleanup (unused usings, double ;, ...)
 * Added .gitkeep in wwwroot so you don't get warnings when initially cloning the repo

Fixes #4 